### PR TITLE
[TEST] Allow to configure prefix for internal Kafka fields

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -45,6 +45,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.kafka.KafkaErrorCode.KAFKA_SPLIT_ERROR;
@@ -91,30 +92,20 @@ public class KafkaFilterManager
 
         if (!constraint.isAll()) {
             Set<Long> partitionIds = partitionInfos.stream().map(partitionInfo -> (long) partitionInfo.partition()).collect(toImmutableSet());
-            Optional<Range> offsetRanged = Optional.empty();
-            Optional<Range> offsetTimestampRanged = Optional.empty();
-            Set<Long> partitionIdsFiltered = partitionIds;
-            Optional<Map<ColumnHandle, Domain>> domains = constraint.getDomains();
 
-            for (Map.Entry<ColumnHandle, Domain> entry : domains.get().entrySet()) {
-                KafkaColumnHandle columnHandle = (KafkaColumnHandle) entry.getKey();
-                if (!columnHandle.isInternal()) {
-                    continue;
-                }
-                switch (columnHandle.getName()) {
-                    case PARTITION_OFFSET_FIELD:
-                        offsetRanged = filterRangeByDomain(entry.getValue());
-                        break;
-                    case PARTITION_ID_FIELD:
-                        partitionIdsFiltered = filterValuesByDomain(entry.getValue(), partitionIds);
-                        break;
-                    case OFFSET_TIMESTAMP_FIELD:
-                        offsetTimestampRanged = filterRangeByDomain(entry.getValue());
-                        break;
-                    default:
-                        break;
-                }
-            }
+            ImmutableMap<String, Domain> domains = constraint.getDomains().orElseThrow()
+                    .entrySet().stream()
+                    .collect(toImmutableMap(
+                            entry -> ((KafkaColumnHandle) entry.getKey()).getName(),
+                            Map.Entry::getValue));
+
+            Optional<Range> offsetRanged = getDomain(PARTITION_OFFSET_FIELD, domains)
+                    .flatMap(KafkaFilterManager::filterRangeByDomain);
+            Set<Long> partitionIdsFiltered = getDomain(PARTITION_ID_FIELD, domains)
+                    .map(domain -> filterValuesByDomain(domain, partitionIds))
+                    .orElse(partitionIds);
+            Optional<Range> offsetTimestampRanged = getDomain(OFFSET_TIMESTAMP_FIELD, domains)
+                    .flatMap(KafkaFilterManager::filterRangeByDomain);
 
             // push down offset
             if (offsetRanged.isPresent()) {
@@ -128,29 +119,32 @@ public class KafkaFilterManager
             // push down timestamp if possible
             if (offsetTimestampRanged.isPresent()) {
                 try (KafkaConsumer<byte[], byte[]> kafkaConsumer = consumerFactory.create(session)) {
-                    Optional<Range> finalOffsetTimestampRanged = offsetTimestampRanged;
                     // filter negative value to avoid java.lang.IllegalArgumentException when using KafkaConsumer offsetsForTimes
                     if (offsetTimestampRanged.get().getBegin() > INVALID_KAFKA_RANGE_INDEX) {
                         partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
-                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getBegin()));
+                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getBegin()));
                     }
                     if (isTimestampUpperBoundPushdownEnabled(session, kafkaTableHandle.getTopicName())) {
                         if (offsetTimestampRanged.get().getEnd() > INVALID_KAFKA_RANGE_INDEX) {
                             partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
-                                    partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getEnd()));
+                                    partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getEnd()));
                         }
                     }
                 }
             }
 
             // push down partitions
-            final Set<Long> finalPartitionIdsFiltered = partitionIdsFiltered;
             List<PartitionInfo> partitionFilteredInfos = partitionInfos.stream()
-                    .filter(partitionInfo -> finalPartitionIdsFiltered.contains((long) partitionInfo.partition()))
+                    .filter(partitionInfo -> partitionIdsFiltered.contains((long) partitionInfo.partition()))
                     .collect(toImmutableList());
             return new KafkaFilteringResult(partitionFilteredInfos, partitionBeginOffsets, partitionEndOffsets);
         }
         return new KafkaFilteringResult(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+    }
+
+    private Optional<Domain> getDomain(String columnName, ImmutableMap<String, Domain> columnNameToDomain)
+    {
+        return Optional.ofNullable(columnNameToDomain.get(columnName));
     }
 
     private boolean isTimestampUpperBoundPushdownEnabled(ConnectorSession session, String topic)

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -45,7 +45,6 @@ import java.util.function.Function;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.kafka.KafkaErrorCode.KAFKA_SPLIT_ERROR;
@@ -92,20 +91,30 @@ public class KafkaFilterManager
 
         if (!constraint.isAll()) {
             Set<Long> partitionIds = partitionInfos.stream().map(partitionInfo -> (long) partitionInfo.partition()).collect(toImmutableSet());
+            Optional<Range> offsetRanged = Optional.empty();
+            Optional<Range> offsetTimestampRanged = Optional.empty();
+            Set<Long> partitionIdsFiltered = partitionIds;
+            Optional<Map<ColumnHandle, Domain>> domains = constraint.getDomains();
 
-            ImmutableMap<String, Domain> domains = constraint.getDomains().orElseThrow()
-                    .entrySet().stream()
-                    .collect(toImmutableMap(
-                            entry -> ((KafkaColumnHandle) entry.getKey()).getName(),
-                            Map.Entry::getValue));
-
-            Optional<Range> offsetRanged = getDomain(PARTITION_OFFSET_FIELD, domains)
-                    .flatMap(KafkaFilterManager::filterRangeByDomain);
-            Set<Long> partitionIdsFiltered = getDomain(PARTITION_ID_FIELD, domains)
-                    .map(domain -> filterValuesByDomain(domain, partitionIds))
-                    .orElse(partitionIds);
-            Optional<Range> offsetTimestampRanged = getDomain(OFFSET_TIMESTAMP_FIELD, domains)
-                    .flatMap(KafkaFilterManager::filterRangeByDomain);
+            for (Map.Entry<ColumnHandle, Domain> entry : domains.get().entrySet()) {
+                KafkaColumnHandle columnHandle = (KafkaColumnHandle) entry.getKey();
+                if (!columnHandle.isInternal()) {
+                    continue;
+                }
+                switch (columnHandle.getName()) {
+                    case PARTITION_OFFSET_FIELD:
+                        offsetRanged = filterRangeByDomain(entry.getValue());
+                        break;
+                    case PARTITION_ID_FIELD:
+                        partitionIdsFiltered = filterValuesByDomain(entry.getValue(), partitionIds);
+                        break;
+                    case OFFSET_TIMESTAMP_FIELD:
+                        offsetTimestampRanged = filterRangeByDomain(entry.getValue());
+                        break;
+                    default:
+                        break;
+                }
+            }
 
             // push down offset
             if (offsetRanged.isPresent()) {
@@ -119,32 +128,29 @@ public class KafkaFilterManager
             // push down timestamp if possible
             if (offsetTimestampRanged.isPresent()) {
                 try (KafkaConsumer<byte[], byte[]> kafkaConsumer = consumerFactory.create(session)) {
+                    Optional<Range> finalOffsetTimestampRanged = offsetTimestampRanged;
                     // filter negative value to avoid java.lang.IllegalArgumentException when using KafkaConsumer offsetsForTimes
                     if (offsetTimestampRanged.get().getBegin() > INVALID_KAFKA_RANGE_INDEX) {
                         partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
-                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getBegin()));
+                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getBegin()));
                     }
                     if (isTimestampUpperBoundPushdownEnabled(session, kafkaTableHandle.getTopicName())) {
                         if (offsetTimestampRanged.get().getEnd() > INVALID_KAFKA_RANGE_INDEX) {
                             partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
-                                    partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getEnd()));
+                                    partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getEnd()));
                         }
                     }
                 }
             }
 
             // push down partitions
+            final Set<Long> finalPartitionIdsFiltered = partitionIdsFiltered;
             List<PartitionInfo> partitionFilteredInfos = partitionInfos.stream()
-                    .filter(partitionInfo -> partitionIdsFiltered.contains((long) partitionInfo.partition()))
+                    .filter(partitionInfo -> finalPartitionIdsFiltered.contains((long) partitionInfo.partition()))
                     .collect(toImmutableList());
             return new KafkaFilteringResult(partitionFilteredInfos, partitionBeginOffsets, partitionEndOffsets);
         }
         return new KafkaFilteringResult(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
-    }
-
-    private Optional<Domain> getDomain(String columnName, ImmutableMap<String, Domain> columnNameToDomain)
-    {
-        return Optional.ofNullable(columnNameToDomain.get(columnName));
     }
 
     private boolean isTimestampUpperBoundPushdownEnabled(ConnectorSession session, String topic)

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
@@ -107,7 +107,7 @@ public class KafkaInternalFieldManager
             return type;
         }
 
-        KafkaColumnHandle getColumnHandle(int index, boolean hidden)
+        KafkaColumnHandle getColumnHandle(boolean hidden)
         {
             return new KafkaColumnHandle(
                     getColumnName(),

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
@@ -107,7 +107,7 @@ public class KafkaInternalFieldManager
             return type;
         }
 
-        KafkaColumnHandle getColumnHandle(boolean hidden)
+        KafkaColumnHandle getColumnHandle(int index, boolean hidden)
         {
             return new KafkaColumnHandle(
                     getColumnName(),

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
@@ -43,7 +43,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -134,13 +133,11 @@ public class KafkaMetadata
 
         ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
 
-        AtomicInteger index = new AtomicInteger(0);
-
         kafkaTopicDescription.getKey().ifPresent(key -> {
             List<KafkaTopicFieldDescription> fields = key.getFields();
             if (fields != null) {
                 for (KafkaTopicFieldDescription kafkaTopicFieldDescription : fields) {
-                    columnHandles.put(kafkaTopicFieldDescription.getName(), kafkaTopicFieldDescription.getColumnHandle(true, index.getAndIncrement()));
+                    columnHandles.put(kafkaTopicFieldDescription.getName(), kafkaTopicFieldDescription.getColumnHandle(true));
                 }
             }
         });
@@ -149,13 +146,13 @@ public class KafkaMetadata
             List<KafkaTopicFieldDescription> fields = message.getFields();
             if (fields != null) {
                 for (KafkaTopicFieldDescription kafkaTopicFieldDescription : fields) {
-                    columnHandles.put(kafkaTopicFieldDescription.getName(), kafkaTopicFieldDescription.getColumnHandle(false, index.getAndIncrement()));
+                    columnHandles.put(kafkaTopicFieldDescription.getName(), kafkaTopicFieldDescription.getColumnHandle(false));
                 }
             }
         });
 
         for (KafkaInternalFieldManager.InternalField kafkaInternalField : kafkaInternalFieldManager.getInternalFields().values()) {
-            columnHandles.put(kafkaInternalField.getColumnName(), kafkaInternalField.getColumnHandle(index.getAndIncrement(), hideInternalColumns));
+            columnHandles.put(kafkaInternalField.getColumnName(), kafkaInternalField.getColumnHandle(hideInternalColumns));
         }
 
         return columnHandles.buildOrThrow();

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSet.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSet.java
@@ -35,7 +35,6 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -56,11 +55,12 @@ import static io.trino.plugin.kafka.KafkaInternalFieldManager.MESSAGE_LENGTH_FIE
 import static io.trino.plugin.kafka.KafkaInternalFieldManager.OFFSET_TIMESTAMP_FIELD;
 import static io.trino.plugin.kafka.KafkaInternalFieldManager.PARTITION_ID_FIELD;
 import static io.trino.plugin.kafka.KafkaInternalFieldManager.PARTITION_OFFSET_FIELD;
-import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static java.lang.Math.max;
 import static java.util.Collections.emptyIterator;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 
 public class KafkaRecordSet
         implements RecordSet
@@ -152,15 +152,14 @@ public class KafkaRecordSet
         @Override
         public boolean advanceNextPosition()
         {
-            if (!records.hasNext()) {
-                if (kafkaConsumer.position(topicPartition) >= split.getMessagesRange().getEnd()) {
-                    return false;
-                }
-                records = kafkaConsumer.poll(Duration.ofMillis(CONSUMER_POLL_TIMEOUT)).iterator();
-                return advanceNextPosition();
+            if (records.hasNext()) {
+                return nextRow(records.next());
             }
-
-            return nextRow(records.next());
+            if (kafkaConsumer.position(topicPartition) >= split.getMessagesRange().getEnd()) {
+                return false;
+            }
+            records = kafkaConsumer.poll(Duration.ofMillis(CONSUMER_POLL_TIMEOUT)).iterator();
+            return advanceNextPosition();
         }
 
         private boolean nextRow(ConsumerRecord<byte[], byte[]> message)
@@ -173,61 +172,28 @@ public class KafkaRecordSet
 
             completedBytes += max(message.serializedKeySize(), 0) + max(message.serializedValueSize(), 0);
 
-            byte[] keyData = EMPTY_BYTE_ARRAY;
-            if (message.key() != null) {
-                keyData = message.key();
-            }
-
-            byte[] messageData = EMPTY_BYTE_ARRAY;
-            if (message.value() != null) {
-                messageData = message.value();
-            }
+            byte[] keyData = message.key() == null ? EMPTY_BYTE_ARRAY : message.key();
+            byte[] messageData = message.value() == null ? EMPTY_BYTE_ARRAY : message.value();
             long timeStamp = message.timestamp();
-
-            Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = new HashMap<>();
 
             Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedKey = keyDecoder.decodeRow(keyData);
             Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = messageDecoder.decodeRow(messageData);
 
-            for (DecoderColumnHandle columnHandle : columnHandles) {
-                if (columnHandle.isInternal()) {
-                    switch (columnHandle.getName()) {
-                        case PARTITION_OFFSET_FIELD:
-                            currentRowValuesMap.put(columnHandle, longValueProvider(message.offset()));
-                            break;
-                        case MESSAGE_FIELD:
-                            currentRowValuesMap.put(columnHandle, bytesValueProvider(messageData));
-                            break;
-                        case MESSAGE_LENGTH_FIELD:
-                            currentRowValuesMap.put(columnHandle, longValueProvider(messageData.length));
-                            break;
-                        case KEY_FIELD:
-                            currentRowValuesMap.put(columnHandle, bytesValueProvider(keyData));
-                            break;
-                        case KEY_LENGTH_FIELD:
-                            currentRowValuesMap.put(columnHandle, longValueProvider(keyData.length));
-                            break;
-                        case OFFSET_TIMESTAMP_FIELD:
-                            timeStamp *= MICROSECONDS_PER_MILLISECOND;
-                            currentRowValuesMap.put(columnHandle, longValueProvider(timeStamp));
-                            break;
-                        case KEY_CORRUPT_FIELD:
-                            currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedKey.isEmpty()));
-                            break;
-                        case HEADERS_FIELD:
-                            currentRowValuesMap.put(columnHandle, headerMapValueProvider((MapType) columnHandle.getType(), message.headers()));
-                            break;
-                        case MESSAGE_CORRUPT_FIELD:
-                            currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedValue.isEmpty()));
-                            break;
-                        case PARTITION_ID_FIELD:
-                            currentRowValuesMap.put(columnHandle, longValueProvider(message.partition()));
-                            break;
-                        default:
-                            throw new IllegalArgumentException("unknown internal field " + columnHandle.getName());
-                    }
-                }
-            }
+            Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = columnHandles.stream()
+                    .filter(KafkaColumnHandle::isInternal)
+                    .collect(toMap(identity(), columnHandle -> switch (columnHandle.getName()) {
+                        case PARTITION_OFFSET_FIELD -> longValueProvider(message.offset());
+                        case MESSAGE_FIELD -> bytesValueProvider(messageData);
+                        case MESSAGE_LENGTH_FIELD -> longValueProvider(messageData.length);
+                        case KEY_FIELD -> bytesValueProvider(keyData);
+                        case KEY_LENGTH_FIELD -> longValueProvider(keyData.length);
+                        case OFFSET_TIMESTAMP_FIELD -> longValueProvider(timeStamp);
+                        case KEY_CORRUPT_FIELD -> booleanValueProvider(decodedKey.isEmpty());
+                        case HEADERS_FIELD -> headerMapValueProvider((MapType) columnHandle.getType(), message.headers());
+                        case MESSAGE_CORRUPT_FIELD -> booleanValueProvider(decodedValue.isEmpty());
+                        case PARTITION_ID_FIELD -> longValueProvider(message.partition());
+                        default -> throw new IllegalArgumentException("unknown internal field " + columnHandle.getName());
+                    }));
 
             decodedKey.ifPresent(currentRowValuesMap::putAll);
             decodedValue.ifPresent(currentRowValuesMap::putAll);

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSet.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSet.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -55,12 +56,11 @@ import static io.trino.plugin.kafka.KafkaInternalFieldManager.MESSAGE_LENGTH_FIE
 import static io.trino.plugin.kafka.KafkaInternalFieldManager.OFFSET_TIMESTAMP_FIELD;
 import static io.trino.plugin.kafka.KafkaInternalFieldManager.PARTITION_ID_FIELD;
 import static io.trino.plugin.kafka.KafkaInternalFieldManager.PARTITION_OFFSET_FIELD;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static java.lang.Math.max;
 import static java.util.Collections.emptyIterator;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 
 public class KafkaRecordSet
         implements RecordSet
@@ -120,7 +120,7 @@ public class KafkaRecordSet
         private Iterator<ConsumerRecord<byte[], byte[]>> records = emptyIterator();
         private long completedBytes;
 
-        private List<FieldValueProvider> currentRowValues = ImmutableList.of();
+        private final FieldValueProvider[] currentRowValues = new FieldValueProvider[columnHandles.size()];
 
         private KafkaRecordCursor()
         {
@@ -152,14 +152,15 @@ public class KafkaRecordSet
         @Override
         public boolean advanceNextPosition()
         {
-            if (records.hasNext()) {
-                return nextRow(records.next());
+            if (!records.hasNext()) {
+                if (kafkaConsumer.position(topicPartition) >= split.getMessagesRange().getEnd()) {
+                    return false;
+                }
+                records = kafkaConsumer.poll(Duration.ofMillis(CONSUMER_POLL_TIMEOUT)).iterator();
+                return advanceNextPosition();
             }
-            if (kafkaConsumer.position(topicPartition) >= split.getMessagesRange().getEnd()) {
-                return false;
-            }
-            records = kafkaConsumer.poll(Duration.ofMillis(CONSUMER_POLL_TIMEOUT)).iterator();
-            return advanceNextPosition();
+
+            return nextRow(records.next());
         }
 
         private boolean nextRow(ConsumerRecord<byte[], byte[]> message)
@@ -172,35 +173,69 @@ public class KafkaRecordSet
 
             completedBytes += max(message.serializedKeySize(), 0) + max(message.serializedValueSize(), 0);
 
-            byte[] keyData = message.key() == null ? EMPTY_BYTE_ARRAY : message.key();
-            byte[] messageData = message.value() == null ? EMPTY_BYTE_ARRAY : message.value();
+            byte[] keyData = EMPTY_BYTE_ARRAY;
+            if (message.key() != null) {
+                keyData = message.key();
+            }
+
+            byte[] messageData = EMPTY_BYTE_ARRAY;
+            if (message.value() != null) {
+                messageData = message.value();
+            }
             long timeStamp = message.timestamp();
+
+            Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = new HashMap<>();
 
             Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedKey = keyDecoder.decodeRow(keyData);
             Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = messageDecoder.decodeRow(messageData);
 
-            Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = columnHandles.stream()
-                    .filter(KafkaColumnHandle::isInternal)
-                    .collect(toMap(identity(), columnHandle -> switch (columnHandle.getName()) {
-                        case PARTITION_OFFSET_FIELD -> longValueProvider(message.offset());
-                        case MESSAGE_FIELD -> bytesValueProvider(messageData);
-                        case MESSAGE_LENGTH_FIELD -> longValueProvider(messageData.length);
-                        case KEY_FIELD -> bytesValueProvider(keyData);
-                        case KEY_LENGTH_FIELD -> longValueProvider(keyData.length);
-                        case OFFSET_TIMESTAMP_FIELD -> longValueProvider(timeStamp);
-                        case KEY_CORRUPT_FIELD -> booleanValueProvider(decodedKey.isEmpty());
-                        case HEADERS_FIELD -> headerMapValueProvider((MapType) columnHandle.getType(), message.headers());
-                        case MESSAGE_CORRUPT_FIELD -> booleanValueProvider(decodedValue.isEmpty());
-                        case PARTITION_ID_FIELD -> longValueProvider(message.partition());
-                        default -> throw new IllegalArgumentException("unknown internal field " + columnHandle.getName());
-                    }));
+            for (DecoderColumnHandle columnHandle : columnHandles) {
+                if (columnHandle.isInternal()) {
+                    switch (columnHandle.getName()) {
+                        case PARTITION_OFFSET_FIELD:
+                            currentRowValuesMap.put(columnHandle, longValueProvider(message.offset()));
+                            break;
+                        case MESSAGE_FIELD:
+                            currentRowValuesMap.put(columnHandle, bytesValueProvider(messageData));
+                            break;
+                        case MESSAGE_LENGTH_FIELD:
+                            currentRowValuesMap.put(columnHandle, longValueProvider(messageData.length));
+                            break;
+                        case KEY_FIELD:
+                            currentRowValuesMap.put(columnHandle, bytesValueProvider(keyData));
+                            break;
+                        case KEY_LENGTH_FIELD:
+                            currentRowValuesMap.put(columnHandle, longValueProvider(keyData.length));
+                            break;
+                        case OFFSET_TIMESTAMP_FIELD:
+                            timeStamp *= MICROSECONDS_PER_MILLISECOND;
+                            currentRowValuesMap.put(columnHandle, longValueProvider(timeStamp));
+                            break;
+                        case KEY_CORRUPT_FIELD:
+                            currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedKey.isEmpty()));
+                            break;
+                        case HEADERS_FIELD:
+                            currentRowValuesMap.put(columnHandle, headerMapValueProvider((MapType) columnHandle.getType(), message.headers()));
+                            break;
+                        case MESSAGE_CORRUPT_FIELD:
+                            currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedValue.isEmpty()));
+                            break;
+                        case PARTITION_ID_FIELD:
+                            currentRowValuesMap.put(columnHandle, longValueProvider(message.partition()));
+                            break;
+                        default:
+                            throw new IllegalArgumentException("unknown internal field " + columnHandle.getName());
+                    }
+                }
+            }
 
             decodedKey.ifPresent(currentRowValuesMap::putAll);
             decodedValue.ifPresent(currentRowValuesMap::putAll);
 
-            currentRowValues = columnHandles.stream()
-                    .map(currentRowValuesMap::get)
-                    .collect(toImmutableList());
+            for (int i = 0; i < columnHandles.size(); i++) {
+                ColumnHandle columnHandle = columnHandles.get(i);
+                currentRowValues[i] = currentRowValuesMap.get(columnHandle);
+            }
 
             return true; // Advanced successfully.
         }
@@ -239,14 +274,14 @@ public class KafkaRecordSet
         public boolean isNull(int field)
         {
             checkArgument(field < columnHandles.size(), "Invalid field index");
-            return currentRowValues.get(field) == null || currentRowValues.get(field).isNull();
+            return currentRowValues[field] == null || currentRowValues[field].isNull();
         }
 
         private FieldValueProvider getFieldValueProvider(int field, Class<?> expectedType)
         {
             checkArgument(field < columnHandles.size(), "Invalid field index");
             checkFieldType(field, expectedType);
-            return currentRowValues.get(field);
+            return currentRowValues[field];
         }
 
         private void checkFieldType(int field, Class<?> expected)

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicFieldDescription.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicFieldDescription.java
@@ -101,7 +101,7 @@ public final class KafkaTopicFieldDescription
         return hidden;
     }
 
-    KafkaColumnHandle getColumnHandle(boolean keyCodec, int index)
+    KafkaColumnHandle getColumnHandle(boolean keyCodec)
     {
         return new KafkaColumnHandle(
                 getName(),

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicFieldDescription.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicFieldDescription.java
@@ -101,7 +101,7 @@ public final class KafkaTopicFieldDescription
         return hidden;
     }
 
-    KafkaColumnHandle getColumnHandle(boolean keyCodec)
+    KafkaColumnHandle getColumnHandle(boolean keyCodec, int index)
     {
         return new KafkaColumnHandle(
                 getName(),

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaInternalFieldManager.java
@@ -53,7 +53,7 @@ public class TestKafkaInternalFieldManager
                         .build();
 
         assertThat(internalField.getColumnName()).isEqualTo(PARTITION_ID_FIELD);
-        assertThat(internalField.getColumnHandle(0, false)).isEqualTo(kafkaColumnHandle);
+        assertThat(internalField.getColumnHandle(false)).isEqualTo(kafkaColumnHandle);
         assertThat(internalField.getColumnMetadata(false)).isEqualTo(columnMetadata);
     }
 }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaInternalFieldManager.java
@@ -53,7 +53,7 @@ public class TestKafkaInternalFieldManager
                         .build();
 
         assertThat(internalField.getColumnName()).isEqualTo(PARTITION_ID_FIELD);
-        assertThat(internalField.getColumnHandle(false)).isEqualTo(kafkaColumnHandle);
+        assertThat(internalField.getColumnHandle(0, false)).isEqualTo(kafkaColumnHandle);
         assertThat(internalField.getColumnMetadata(false)).isEqualTo(columnMetadata);
     }
 }


### PR DESCRIPTION
mimic https://github.com/trinodb/trino/pull/14224

Test fail below is not reproducible locally. Trying to reproduce it in this pr.

ci / pt (default, suite-6-non-generic, ) (pull_request) https://github.com/trinodb/trino/actions/runs/3111929833/jobs/5045112147
```
tests               | 2022-09-22 23:00:02 INFO: FAILURE     /    io.trino.tests.product.kafka.TestKafkaPushdownSmokeTest.testCreateTimePushdown (Groups: profile_specific_tests, kafka) took 6.0 seconds
tests               | 2022-09-22 23:00:02 SEVERE: Failure cause:
tests               | java.lang.AssertionError: Not equal rows:
tests               | 0 - expected: 2|
tests               | 0 - actual:   3|
tests               | 	at io.trino.tests.product.kafka.TestKafkaPushdownSmokeTest.testCreateTimePushdown(TestKafkaPushdownSmokeTest.java:190)
tests               | 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
tests               | 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
tests               | 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
tests               | 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
tests               | 	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
tests               | 	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
tests               | 	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
tests               | 	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
tests               | 	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
tests               | 	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
tests               | 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
tests               | 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
tests               | 	at java.base/java.lang.Thread.run(Thread.java:833)
```